### PR TITLE
Add BlockType to If instruction to comply with wasm spec

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -330,7 +330,7 @@ impl CodeBuilder {
     gen_builder!(Nop, nop);
     gen_builder!(Block { sig: BlockType }, block);
     gen_builder!(Loop { sig: BlockType }, loop_);
-    gen_builder!(If, if_);
+    gen_builder!(If { sig: BlockType }, if_);
     gen_builder!(Else, else_);
     gen_builder!(End, end);
     gen_builder!(Br { depth: u32 }, br);

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -8,7 +8,7 @@ pub enum Op {
     Nop,
     Block { sig: BlockType },
     Loop { sig: BlockType },
-    If,
+    If { sig: BlockType },
     Else,
     End,
     // TODO: use relative block index
@@ -222,7 +222,10 @@ impl Dump for Op {
                 size += write_uint8(buf, 0x03);
                 size += sig.dump(buf);
             }
-            &If => size += write_uint8(buf, 0x04),
+            &If { ref sig } => {
+                size += write_uint8(buf, 0x04);
+                size += sig.dump(buf);
+            }
             &Else => size += write_uint8(buf, 0x05),
             &End => size += write_uint8(buf, 0x0b),
             &Br { ref depth } => {


### PR DESCRIPTION
https://webassembly.github.io/spec/core/syntax/instructions.html#control-instructions

Like `block` and `loop`, `if` is supposed to take a BlockType, and it not having one causes use of it to throw a validation error when loading the module (e.g. in Firefox).